### PR TITLE
Update to new Auth service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # OmniAuth OAuth2 for Kaeuferportal
+
+This strategy allows clients that have been registered with Käuferportal
+to use https://auth.kaeuferportal.de as Authentication server.

--- a/lib/omniauth-kaeuferportal/version.rb
+++ b/lib/omniauth-kaeuferportal/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Kaeuferportal
-    VERSION = "1.1.0"
+    VERSION = '2.0.0'
   end
 end

--- a/lib/omniauth/strategies/kaeuferportal.rb
+++ b/lib/omniauth/strategies/kaeuferportal.rb
@@ -1,169 +1,36 @@
-require 'cgi'
-require 'uri'
-require 'oauth2'
-require 'omniauth'
-require 'timeout'
-require 'securerandom'
-
-module OAuth2
-  class Client
-    def get_token(params, access_token_opts={})
-      opts = {:raise_errors => true, :parse => params.delete(:parse)}
-      if options[:token_method] == :post
-        opts[:body] = params
-        opts[:headers] =  {                                                                                                                                                 
-          'Content-Type' => 'application/x-www-form-urlencoded',                   
-          'Accept-Encoding' => ''                                                  
-        }
-      else
-        opts[:params] = params
-      end
-      response = request(options[:token_method], token_url, opts)
-      raise Error.new(response) unless response.body['access_token']
-      opts = {
-        :access_token => response.body.split("=")[1],
-        :param_name => 'token'
-      }
-      AccessToken.from_hash(self, opts.merge(access_token_opts))
-    end
-  end
-end
+require 'omniauth/strategies/oauth2'
 
 module OmniAuth
   module Strategies
-    # Authentication strategy for connecting with APIs constructed using
-    # the [OAuth 2.0 Specification](http://tools.ietf.org/html/draft-ietf-oauth-v2-10).
-    # You must generally register your application with the provider and
-    # utilize an application id and secret in order to authenticate using
-    # OAuth 2.0.
-    class Kaeuferportal
-      include OmniAuth::Strategy
-
-      args [:client_id, :client_secret]
-
+    class Kaeuferportal < OmniAuth::Strategies::OAuth2
       option :name, "kaeuferportal"
-      option :client_id, nil
-      option :client_secret, nil
-      option :authorize_params, {}
-      option :authorize_options, [:scope]
-      option :token_params, {}
-      option :token_options, []
       option :client_options, {
-        :site => 'https://www.kaeuferportal.de',
-        :authorize_url => '/oauth/authorize',
-        :token_url => '/oauth/access_token'
+        site: 'https://auth.kaueferportal.de',
+        authorize_url: '/oauth/authorize',
+        token_url: '/oauth/token'
       }
 
-
-      attr_accessor :access_token
-
-      def client
-        ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
-      end
-
-      def callback_url
-        full_host + script_name + callback_path
-      end
-
-      credentials do
-        hash = {'token' => access_token.token}
-        hash.merge!('refresh_token' => access_token.refresh_token) if access_token.expires? && access_token.refresh_token
-        hash.merge!('expires_at' => access_token.expires_at) if access_token.expires?
-        hash.merge!('expires' => access_token.expires?)
-        hash
-      end
-
-      def request_phase
-        redirect client.auth_code.authorize_url({:redirect_url => callback_url}.merge(authorize_params))
-      end
-
-      def authorize_params
-        if options.authorize_params[:state].to_s.empty?
-          options.authorize_params[:state] = SecureRandom.hex(24)
-        end
-        params = options.authorize_params.merge(options.authorize_options.inject({}){|h,k| h[k.to_sym] = options[k] if options[k]; h})
-        if OmniAuth.config.test_mode
-          @env ||= {}
-          @env['rack.session'] ||= {}
-        end
-        session['omniauth.state'] = params[:state]
-        params
-      end
-
-      def token_params
-        options.token_params.merge(options.token_options.inject({}){|h,k| h[k.to_sym] = options[k] if options[k]; h})
-      end
-
-      def callback_phase
-        if request.params['error'] || request.params['error_reason']
-          raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])
-        end
-        if request.params['state'].to_s.empty? || request.params['state'] != session.delete('omniauth.state')
-          raise CallbackError.new(nil, :csrf_detected)
-        end
-
-        self.access_token = build_access_token
-        self.access_token = access_token.refresh! if access_token.expired?
-
-        super
-      rescue ::OAuth2::Error, CallbackError => e
-        fail!(:invalid_credentials, e)
-      rescue ::MultiJson::DecodeError => e
-        fail!(:invalid_response, e)
-      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
-        fail!(:timeout, e)
-      rescue ::SocketError => e
-        fail!(:failed_to_connect, e)
-      end
-
-      # These are called after authentication has succeeded. If
-      # possible, you should try to set the UID without making
-      # additional calls (if the user id is returned with the token
-      # or as a URI parameter). This may not be possible with all
-      # providers.
-      uid { raw_info['uuid'] }
+      uid { user_info['sub'] }
 
       info do
         {
-          :name => @raw_info['email'].split("@")[0],
-          :email => @raw_info['email']
+          name: user_info['name'],
+          email: user_info['email']
         }
       end
 
-      def raw_info
-        access_token.options[:mode] = :query
-        access_token.options[:param_name] = 'oauth_token'
-        access_token.client.connection.headers['Accept-Encoding'] = ''
-        @raw_info ||= access_token.get('/oauth/user').parsed
+      def user_info
+        @user_info ||= access_token.get('/api/users/current').parsed
       end
 
-      protected
-
-      def deep_symbolize(hash)
-        hash.inject({}) do |h, (k,v)|
-          h[k.to_sym] = v.is_a?(Hash) ? deep_symbolize(v) : v
-          h
-        end
-      end
-
-      def build_access_token
-        verifier = request.params['code']
-        client.auth_code.get_token(verifier, {:redirect_url => callback_url}.merge(token_params.to_hash(:symbolize_keys => true)))
-      end
-
-      # An error that is indicated in the OAuth 2.0 callback.
-      # This could be a `redirect_uri_mismatch` or other
-      class CallbackError < StandardError
-        attr_accessor :error, :error_reason, :error_uri
-
-        def initialize(error, error_reason=nil, error_uri=nil)
-          self.error = error
-          self.error_reason = error_reason
-          self.error_uri = error_uri
-        end
+      # This method override was once part of omniauth-oauth2, but was removed
+      # in https://github.com/intridea/omniauth-oauth2/pull/70
+      # However, this causes Doorkeeper to reject the redirect_uri, as I explain
+      # here: https://github.com/intridea/omniauth-oauth2/issues/28#issuecomment-199382532
+      def callback_url
+        full_host + script_name + callback_path
       end
     end
   end
 end
 OmniAuth.config.add_camelization 'kaeuferportal', 'Kaeuferportal'
-

--- a/omniauth-kaeuferportal.gemspec
+++ b/omniauth-kaeuferportal.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'omniauth', '~> 1.3'
   gem.add_dependency 'omniauth-oauth2', '~> 1.4'
 
-  gem.add_development_dependency 'rspec', '~> 2.7'
+  gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'simplecov'

--- a/omniauth-kaeuferportal.gemspec
+++ b/omniauth-kaeuferportal.gemspec
@@ -2,8 +2,8 @@
 require File.expand_path('../lib/omniauth-kaeuferportal/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'omniauth', '~> 1.1.0'
-  gem.add_dependency 'oauth2', '=0.7.1'
+  gem.add_dependency 'omniauth', '~> 1.3'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.4'
 
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'

--- a/spec/omniauth/strategies/kaeuferportal_spec.rb
+++ b/spec/omniauth/strategies/kaeuferportal_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::Kaeuferportal do
-  def app; lambda{|env| [200, {}, ["Hello."]]} end
+  def app
+    lambda { |env| [200, {}, ["Hello."]] }
+  end
+
   let(:fresh_strategy){ Class.new(OmniAuth::Strategies::Kaeuferportal) }
 
   before do
@@ -12,52 +15,17 @@ describe OmniAuth::Strategies::Kaeuferportal do
     OmniAuth.config.test_mode = false
   end
 
-  describe '#client' do
+  describe '#client_options' do
     subject{ fresh_strategy }
 
     it 'should be initialized with symbolized client_options' do
-      instance = subject.new(app, :client_options => {'authorize_url' => 'https://example.com'})
-      instance.client.options[:authorize_url].should == 'https://example.com'
+      instance = subject.new(app, client_options: { 'authorize_url' => 'https://example.com' })
+      expect(instance.client.options[:authorize_url]).to eql 'https://example.com'
     end
 
     it 'should set ssl options as connection options' do
-      instance = subject.new(app, :client_options => {'ssl' => {'ca_path' => 'foo'}})
-      instance.client.options[:connection_opts][:ssl] =~ {:ca_path => 'foo'}
-    end
-  end
-
-  describe '#authorize_params' do
-    subject { fresh_strategy }
-
-    it 'should include any authorize params passed in the :authorize_params option' do
-      instance = subject.new('abc', 'def', :authorize_params => {:foo => 'bar', :baz => 'zip', :state => '123'})
-      instance.authorize_params.should == {'foo' => 'bar', 'baz' => 'zip', 'state' => '123'}
-    end
-
-    it 'should include top-level options that are marked as :authorize_options' do
-      instance = subject.new('abc', 'def', :authorize_options => [:scope, :foo], :scope => 'bar', :foo => 'baz', :authorize_params => {:state => '123'})
-      instance.authorize_params.should == {'scope' => 'bar', 'foo' => 'baz', 'state' => '123'}
-    end
-
-    it 'should include random state in the authorize params' do
-      instance = subject.new('abc', 'def')
-      instance.authorize_params.keys.should == ['state']
-      instance.session['omniauth.state'].should_not be_empty
-      instance.session['omniauth.state'].should == instance.authorize_params['state']
-    end
-  end
-
-  describe '#token_params' do
-    subject { fresh_strategy }
-
-    it 'should include any authorize params passed in the :authorize_params option' do
-      instance = subject.new('abc', 'def', :token_params => {:foo => 'bar', :baz => 'zip'})
-      instance.token_params.should == {'foo' => 'bar', 'baz' => 'zip'}
-    end
-
-    it 'should include top-level options that are marked as :authorize_options' do
-      instance = subject.new('abc', 'def', :token_options => [:scope, :foo], :scope => 'bar', :foo => 'baz')
-      instance.token_params.should == {'scope' => 'bar', 'foo' => 'baz'}
+      instance = subject.new(app, client_options: { 'ssl' => { 'ca_path' => 'foo' } })
+      instance.client.options[:connection_opts][:ssl] =~ { ca_path: 'foo' }
     end
   end
 end


### PR DESCRIPTION
This PR updates the gem to use our new auth service, that is based on doorkeeper.

This allows us to remove a bunch of custom code, that was required to work with the old provider.
Now this is a pretty straight-forward omniauth-oauth2 strategy.